### PR TITLE
Add helper text and char count for notes

### DIFF
--- a/Autinaut/Resx/AppResources.Designer.cs
+++ b/Autinaut/Resx/AppResources.Designer.cs
@@ -96,6 +96,15 @@ namespace Autinaut.Resx {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Max 500 Zeichen.
+        /// </summary>
+        public static string EmotionNoteMaxChars {
+            get {
+                return ResourceManager.GetString("EmotionNoteMaxChars", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Beschreibe die Situation.
         /// </summary>
         public static string HintInputSituation {
@@ -281,6 +290,15 @@ namespace Autinaut.Resx {
         public static string SuccessItemsPageTitle {
             get {
                 return ResourceManager.GetString("SuccessItemsPageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Max 700 Zeichen.
+        /// </summary>
+        public static string SuccessNoteMaxChars {
+            get {
+                return ResourceManager.GetString("SuccessNoteMaxChars", resourceCulture);
             }
         }
         

--- a/Autinaut/Resx/AppResources.en.resx
+++ b/Autinaut/Resx/AppResources.en.resx
@@ -252,4 +252,10 @@
     <data name="TextSfButtonSave" xml:space="preserve">
     <value>Save</value>
   </data>
+    <data name="EmotionNoteMaxChars" xml:space="preserve">
+      <value>Max 500 chars</value>
+    </data>
+    <data name="SuccessNoteMaxChars" xml:space="preserve">
+      <value>Max 700 chars</value>
+    </data>
 </root>

--- a/Autinaut/Resx/AppResources.resx
+++ b/Autinaut/Resx/AppResources.resx
@@ -252,4 +252,10 @@
     <data name="TextSfButtonSave" xml:space="preserve">
     <value>Speichern</value>
   </data>
+    <data name="SuccessNoteMaxChars" xml:space="preserve">
+      <value>Max 700 Zeichen</value>
+    </data>
+    <data name="EmotionNoteMaxChars" xml:space="preserve">
+      <value>Max 500 Zeichen</value>
+    </data>
 </root>

--- a/Autinaut/Views/EmotionItemPage.xaml
+++ b/Autinaut/Views/EmotionItemPage.xaml
@@ -44,6 +44,9 @@
                         FocusedColor="#562b28"
                         FocusedStrokeWidth="0"
                         Hint="{x:Static resources:AppResources.HintInputSituation}"
+                        HelperText="{x:Static resources:AppResources.EmotionNoteMaxChars}"
+                        CharMaxLength="500"
+                        ShowCharCount="True"
                         UnfocusedColor="Black"
                         UnfocusedStrokeWidth="1">
                         <Editor

--- a/Autinaut/Views/SuccessItemPage.xaml
+++ b/Autinaut/Views/SuccessItemPage.xaml
@@ -37,6 +37,9 @@
                     FocusedColor="#562b28"
                     FocusedStrokeWidth="0"
                     Hint="{x:Static resources:AppResources.HintInputSuccess}"
+                    HelperText="{x:Static resources:AppResources.SuccessNoteMaxChars}"
+                    CharMaxLength="700"
+                    ShowCharCount="True"
                     UnfocusedColor="Black"
                     UnfocusedStrokeWidth="1">
                     <Editor


### PR DESCRIPTION
Show the user a hint how long a text entry is allowed to be and show him the number of characters of his current entry.